### PR TITLE
fixed script for ChromeWebdriver 75+

### DIFF
--- a/from_list.py
+++ b/from_list.py
@@ -44,9 +44,8 @@ options.add_argument('headless')
 
 # See https://sites.google.com/a/chromium.org/chromedriver/logging/performance-log
 # and https://docs.seleniumhq.org/docs/04_webdriver_advanced.jsp#remotewebdriver
-capbs = webdriver.DesiredCapabilities.CHROME.copy()
-capbs.update({'loggingPrefs': {'performance': 'ALL'}, 'detach': False})
-
+capbs = webdriver.DesiredCapabilities.CHROME
+capbs["goog:loggingPrefs"] = {"performance": "ALL"}  # chromedriver 75+
 
 # 2. Crawls each website.
 tot_lf_enc_data_len = {}


### PR DESCRIPTION
* Newer versions of the ChromeWebdriver (75+) require slightly updated desired capability settings, this is to be in compliance with W3C standards.
* This fix is required for the script to run with newer ChromeWebdriver versions, otherwise the error `log type 'performance' not found` is raised.